### PR TITLE
Added 404.md file and 404 layout file

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,4 @@
+---
+layout: "404"
+title: "Page Not Found"
+---  

--- a/_layouts/404.html
+++ b/_layouts/404.html
@@ -1,0 +1,20 @@
+{% include head-dark.html %}
+
+<section class="article pad-top">
+
+      <article class="wrap post">
+        <header class="post-header">
+          <hgroup>
+            <h1>{{ page.title }}</h1>
+            <p class="intro">{% if page.description %}{{ page.description }}{% else %}{{ page.tagline }}{% endif %}</p>
+
+          </hgroup>
+        </header>
+
+        {{ content }}
+
+      </article>
+    </section>
+</div>
+
+{% include footer.html %}


### PR DESCRIPTION
initial custom 404 page.

feel free to change - I based the 404.html page off of page.html and removed some things like the 'share' button.

In the 404.md file you will notice that I had to put 404 in quotes - i.e. "404"; this is because without quotes using a layout name that begins with a number appears to be a bug w/ Jekyll. I thought having the 404 layout file named '404.html' the most straight forward approach.
