### PR TITLE
Remove pygments deprecation warning for Jekyll 2+

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ links:
 # http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 timezone:    America/New_York
 future:      true
-pygments:    true
+highlighter: pygments
 markdown:    kramdown
 
 kramdown:


### PR DESCRIPTION
Simple change to _config.yml to update the pygments sonfig setting to correct one for Jekyll 2+, removing deprecation warning on serve.
