### PR TITLE
Add feature about feature image has a link address

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,13 @@ A good rule of thumb is to keep feature images nice and wide so you don't push t
 
 ``` yaml
 image:
+# local image 
   feature: feature-image-filename.jpg
+# link image
+  feature: "http(s)://image.domain.com/feature-image-filename.jpg"
 ```
 
-This makes the assumption that the feature image is in the *images* folder. To add a feature image to a post or page just include the filename in the front matter like so.
+This makes the assumption that the feature image is in the *images* folder unless it has a link address. To add a feature image to a post or page just include the filename in the front matter like so.
 You can "serve" images responsively with retina.js. All you need to do is have a file with @2x before the file type. That should be placed in the *images* folder. You literally don't have to do anything other than that. 2 copies. One is linked. That's it.
 Ex:
 `cool-photo@2x.jpg` 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,11 @@
 
 {% if page.image.feature %}
   <div class="overlay"></div>
+  {% if page.image.feature contains 'https://' | escape or page.image.feature contains 'http://' | escape %}
+  <div class="featured-image" style="background-image: url({{ page.image.feature }})"></div>
+  {% else %}
   <div class="featured-image" style="background-image: url({{ site.url }}/images/{{ page.image.feature }})"></div>
+  {% endif %}
 {% else %}
   <div class="overlay"></div>
   <div class="featured-image" style="background-image: url({{ site.url }}/images/typewriter.jpg)"></div>

--- a/_posts/2013-08-05-post-with-feature.md
+++ b/_posts/2013-08-05-post-with-feature.md
@@ -5,7 +5,7 @@ description: "In my younger and more vulnerable years my father gave me some adv
 category: articles
 tags: [intro, beginner, jekyll, tutorial]
 image:
-  feature: gatsby.jpg
+  feature: "https://farm8.staticflickr.com/7014/6840341477_e49612bc59_o_d.jpg"
 ---
 
 “Whenever you feel like criticizing any one,” he told me, “just remember that all the people in this world haven’t had the advantages that you’ve had.”


### PR DESCRIPTION
I do very much appreciate this theme of Jekyll. I have decided to use it for my blog.

Feature image is a good idea but it didn't be supported to set a address from Internet. Consider the convenience when we want to use a external image in order to reduce the size of Jekyll itself, I add this feature.

Let's improve it together~
