### PR TITLE
Fix type

### DIFF
--- a/_sass/_mixins.scss
+++ b/_sass/_mixins.scss
@@ -84,7 +84,7 @@
 @mixin box-rgba($r: 60, $g: 3, $b: 12, $opacity: 0.23, $color: #3C3C3C) {
   background-color: transparent;
   background-color: rgba($r, $g, $b, $opacity);
-            filter: progid:DXImageTransform.Microsoft.gradient(startColorstr#$color,endColorstr=$color);
+            filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=$color,endColorstr=$color);
             zoom:   1;
 }
 


### PR DESCRIPTION
Fix typo of scss file.
Replace from '#' to `=`.

Error message:
```bash
Conversion error: Jekyll::Converters::Scss encountered an error while converting 'assets/css/i.scss':
Error: Invalid CSS after "...t(startColorstr": expected expression (e.g. 1px, bold), was "#$color,endColorstr" on line 87:77 of _sass/_mixins.scss from line 8:1 of i.scss >> Transform.Microsoft.gradient(startColorstr#$color,endColorstr=$color); 
------------------------------------------^
------------------------------------------------
Jekyll 4.0.0   Please append `--trace` to the `serve` command for any additional 
information or backtrace.
------------------------------------------------
```